### PR TITLE
test: replace expect(true) placeholders with real greeting() assertions

### DIFF
--- a/packages/package-a/__tests__/sample.test.ts
+++ b/packages/package-a/__tests__/sample.test.ts
@@ -1,55 +1,61 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
+import { greeting } from '../src/index'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+// These tests deliberately have varying durations so the GitHub Actions
+// orchestration in `.github/workflows/test.yml` has something to schedule.
+// The assertions are real (not `expect(true).toBe(true)`) so the suite stays
+// honest if `greeting` ever regresses.
 describe('Package A Tests', () => {
-  it('runs simple test 1', async () => {
+  it('runs greeting test (fast 1)', async () => {
     await sleep(1000)
-    expect(true).toBe(true)
+    expect(greeting('Alice')).toBe('Hello, Alice!')
   })
 
-  it('runs simple test 2', async () => {
+  it('runs greeting test (slow 1)', async () => {
     await sleep(5000)
-    expect(true).toBe(true)
+    expect(greeting('Bob')).toBe('Hello, Bob!')
   })
 
-  it('runs simple test 3', async () => {
+  it('runs greeting test (fast 2)', async () => {
     await sleep(1000)
-    expect(true).toBe(true)
+    expect(greeting('Carol')).toBe('Hello, Carol!')
   })
 
-  it('runs simple test 4', async () => {
+  it('runs greeting test (slow 2)', async () => {
     await sleep(5000)
-    expect(true).toBe(true)
+    expect(greeting('Dave')).toBe('Hello, Dave!')
   })
 
-  it('runs simple test 5', async () => {
+  it('runs greeting test (fast 3)', async () => {
     await sleep(1000)
-    expect(true).toBe(true)
+    expect(greeting('Eve')).toBe('Hello, Eve!')
   })
 
-  it('runs simple test 6', async () => {
+  it('runs greeting test (slow 3)', async () => {
     await sleep(5000)
-    expect(true).toBe(true)
+    expect(greeting('Frank')).toBe('Hello, Frank!')
   })
 
-  it('runs simple test 7', async () => {
+  it('runs greeting test (fast 4)', async () => {
     await sleep(1000)
-    expect(true).toBe(true)
+    expect(greeting('Grace')).toBe('Hello, Grace!')
   })
 
-  it('runs simple test 8', async () => {
+  it('runs greeting test (slow 4)', async () => {
     await sleep(5000)
-    expect(true).toBe(true)
+    expect(greeting('Heidi')).toBe('Hello, Heidi!')
   })
 
-  it('runs simple test 9', async () => {
+  it('runs greeting test (fast 5)', async () => {
     await sleep(1000)
-    expect(true).toBe(true)
+    expect(greeting('Ivan')).toBe('Hello, Ivan!')
   })
 
-  it('runs simple test 10', async () => {
+  it('runs greeting test (slow 5)', async () => {
     await sleep(5000)
-    expect(true).toBe(true)
+    expect(greeting('Judy')).toBe('Hello, Judy!')
   })
 })


### PR DESCRIPTION
## What

Replace the `expect(true).toBe(true)` placeholder assertions in
`packages/package-a/__tests__/sample.test.ts` with real assertions
against `greeting()`.

The orchestration demo wants tests with **controlled durations** — not
fake assertions. Each test now exercises `greeting()` with a different
name input, so the suite still has the staggered fast/slow timing the
workflow demo needs, but it stays honest if `greeting()` ever
regresses.

## Why

Per the new global rule **"Never weaken a test to make it pass"**,
`expect(true).toBe(true)` is the canonical example of a test that
passes by design and is not pulling its weight. This was a
pre-existing pattern in the demo — surfacing it now in the
quality-tightening sprint.

## Verified locally

- `yarn workspace @gha-test-orchestrator/package-a test` — 13 / 13
  pass. 100 % coverage (statements / branches / functions / lines)
  on `src/index.ts`.
- `yarn lint` / `yarn format:check` / `yarn typecheck` — clean.
